### PR TITLE
Fix slashes in "deprecated" tag paths

### DIFF
--- a/Manual/contents/GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/health.htm
+++ b/Manual/contents/GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/health.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">health</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">health</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>这个变量是<b>全局</b>范围的，用来保存一个数字值，通常用来表示玩家的健康状况。这个变量只是为了支持<i>GameMaker</i>以前版本的遗留项目，并且应该 <b><i>在新项目中不使用</i></b>因为它在未来可能会被废弃。</p>
   <p> </p>
   <h4>语法。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/lives.htm
+++ b/Manual/contents/GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/lives.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">lives</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">lives</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>这个变量是<b>全局</b>范围的，用来保存一个数字值，通常用于玩家的生命。这个变量只是为了支持<i>GameMaker</i>以前版本的遗留项目而设计的，并应 <b><i>不用于新项目中</i></b>因为它在未来可能会被废弃。</p>
   <p> </p>
   <h4>语法。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/score.htm
+++ b/Manual/contents/GameMaker_Language/GML_Overview/Variables/Builtin_Global_Variables/score.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">score</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">score</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>这个变量是<b>全局</b>范围的，用来保存一个数字值，通常用来表示玩家的得分。这个变量只是为了支持<i>GameMaker</i>以前版本的遗留项目，并且应该 <b><i>不用于新项目中</i></b>因为它在未来可能会被废弃。</p>
   <p> </p>
   <h4>语法。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Fonts/font_get_first.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Fonts/font_get_first.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">font_get_first</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">font_get_first</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>当在<span data-keyref="GameMaker Name">GameMaker</span>中定义一个<span class="notranslate">font</span> ，你可以定义一个包括的字符范围。这是因为<span class="notranslate">font</span> 本身实际上并不包括在你的<i></i>游戏中（出于法律原因），但一个 的图像包含在一个 页面上，这就是你的游戏要使用的东西（就像其他图形 ）。
     <span class="notranslate">font</span> 的图像包含在<span class="notranslate">texture</span> 页面上，这就是你的游戏将使用的东西（就像任何其他图形<span class="notranslate">asset</span> ）。这意味着你要尽量减少使用的字符数，只指定你的游戏需要的字符范围。
     你的游戏将需要的字符范围，以便尽可能地优化<span class="notranslate">texture</span> 内存。这个函数可以用来查找当你的<span class="notranslate">font</span> <span class="notranslate">asset</span> 被添加到你的游戏中时使用的起始字符（作为ASCII值）。</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Instances/instance_change.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Instances/instance_change.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">instance_change</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">instance_change</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>你可以使用这个函数将一个<span class="notranslate">object</span> ，变成另一个不同的<span class="notranslate">object</span> ，并在这样做的同时决定是否执行初始实例的Destroy和Clean Up事件以及新实例的Create事件。这样，你可以让（例如）一个炸弹变成一个爆炸--在这种情况下，&quot;perf &quot;参数可能为真，因为你希望炸弹执行其销毁事件和清理事件，以及爆炸执行其创建事件--或者你可以让你的玩家角色变成另一个角色--在这种情况下，&quot;perf &quot;参数可能为假，因为你不希望实例执行其创建和销毁/清理事件。</p>
   <p>值得注意的是，改变实例意味着在下一步之前，你不应该对该实例执行进一步的操作，特别是试图访问变量等......因为这将导致一个错误。基本上，你改变了这个实例，但是在当前步骤结束之前，它实际上是不可用的，所以直接访问它所包含的任何变量（例如，调用 <span class="inline">obj_Changed.x</span> ）是不可行的。</p>
   <p class="note"><b>WARNING!</b>当改变一个启用了物理功能的实例时，物理属性<b>将不会被</b>转移到被改变的新实例中。因此，你应该有代码将当前实例的物理状态 &quot;转移 &quot;到新的实例上，或者在其创建事件中定义新实例的物理属性，或者在<span class="notranslate">object</span> 编辑器中。由于这个原因，我们建议你不要在启用物理的实例中使用这个函数，而应该使用 <span style="font-size:1px;"><span class="inline">instance_destroy()</span></span>和<span><span style="font-size:1px;"><span class="inline">instance_create_layer()</span></span></span>。</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Objects/Object_Events/event_action.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Objects/Object_Events/event_action.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">event_action</span> <span data-conref="..\..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">event_action</span> <span data-conref="../../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>这个<b>只读</b>变量返回当前正在执行的动作的索引，在以前的版本中从0开始<span class="notranslate">GameMaker</span> 。然而，在<span data-keyref="GameMaker Name">GameMaker</span>中这是<b>一个过时的变量 </b>。它被保留下来只是为了支持传统，并将<b>永远返回0</b>，因为所有的动作都被串联在一起以提高执行速度。</p>
   <p> </p>
   <h4>语法。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/room_speed.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asset_Management/Rooms/room_speed.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">room_speed</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">room_speed</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>这个变量持有<b>所有</b> <span class="notranslate">rooms</span> （和游戏）的运行速度，单位是游戏帧/秒。请注意，这<i>不是</i>FPS（每秒帧数），而是<span data-keyref="GameMaker Name">GameMaker</span>试图保持每秒的游戏步骤数。
     秒。</p>
   <p class="note"><b>重要的是!</b>这个变量只为传统支持而保留，不应该被使用，因为它不再为单个<span class="notranslate">room</span> ，而是为游戏中的所有<span class="notranslate">rooms</span> ，设置速度。要改变游戏速度，你应该使用函数 <span style="font-size:1px;"><a href="../../General_Game_Control/game_set_speed.htm"><span class="inline">game_set_speed()</span></a></span>.</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/Cloud_Saving/cloud_file_save.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/Cloud_Saving/cloud_file_save.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">cloud_file_save</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">cloud_file_save</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>该函数将提交一个文件到所选择的云服务进行存储。该函数将返回一个唯一的<b>ID</b>值，然后应该在适当的异步事件中使用，以识别作为云服务 &quot;回调 &quot;返回的DS地图。该文件应该包含你需要为你的游戏保存的<i>所有</i>信息，因为你只能将一个单一的 &quot;数据块 &quot;存储到云端，再次运行该函数将覆盖任何先前存储的值（正如使用 <a href="cloud_string_save.htm"><span class="inline">cloud_string_save()</span></a>函数）。描述应该是一个简短的<span class="notranslate">string</span> ，描述保存的信息，例如：&quot;Level2, Stage2&quot;。</p>
   <p>关于返回的异步数据的进一步信息，请参见函数 <a href="cloud_synchronise.htm"><span class="inline">cloud_synchronise()</span></a>.</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/Cloud_Saving/cloud_string_save.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/Cloud_Saving/cloud_string_save.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">cloud_string_save</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">cloud_string_save</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>这个函数将提交一个<span class="notranslate">string</span> 到所选择的云服务进行存储。该函数将返回一个唯一的<b>ID</b>值，然后应该在适当的异步事件中使用，以识别作为云服务 &quot;回调 &quot;返回的DS地图。<span class="notranslate">string</span> 应该包含你需要为你的游戏保存的<i>所有</i>信息，因为你只能将一个单一的 &quot;数据块 &quot;存储到云端，再次运行这个函数将覆盖任何先前存储的值（正如使用 <a href="cloud_file_save.htm"><span class="inline">cloud_file_save()</span></a>函数）。描述应该是一个简短的<span class="notranslate">string</span> ，描述保存的信息，例如：&quot;Level2, Stage2&quot;。</p>
   <p>关于返回的异步数据的进一步信息，请参见函数 <a href="cloud_synchronise.htm"><span class="inline">cloud_synchronise()</span></a>.</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/Cloud_Saving/cloud_synchronise.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Asynchronous_Functions/Cloud_Saving/cloud_synchronise.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">cloud_synchronise</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">cloud_synchronise</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>这个函数通常会在新游戏开始时被调用，用于在游戏启动时检索云服务的当前状态。该函数返回一个唯一的<b>ID</b>值，然后在<a href="../../../../The_Asset_Editors/Object_Properties/Async_Events/Cloud.htm">异步云事件</a>中使用，从创建的DS地图中检索相关信息。</p>
   <p>这个函数将向云端发送数据，然后会触发相应的异步事件。在这个事件中，你可以检查返回的 <a href="../../../GML_Overview/Variables/Builtin_Global_Variables/async_load.htm"><span class="inline">async_load</span></a>DS地图的下列值。</p>
   <ul class="colour">

--- a/Manual/contents/GameMaker_Language/GML_Reference/Cameras_And_Display/The_Game_Window/window_device.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Cameras_And_Display/The_Game_Window/window_device.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">window_device</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">window_device</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>这个函数将返回当前的d3d设备<i>指针</i>，然后你可以（例如）将其传递给<span class="notranslate">Windows</span> 和<span class="notranslate">macOS</span> 上的DLL或Dylib。</p>
   <p class="note"><span class="note">注意</span>在<span data-keyref="GameMaker Name">GameMaker</span>中，这个函数已被废弃，改为使用 <a href="../../OS_And_Compiler/os_get_info.htm"><span style="font-size:1px;"><span class="inline">os_get_info()</span></span></a>.</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/get_integer.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/get_integer.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">get_integer</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">get_integer</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>这将创建一个弹出式窗口，显示一个自定义信息，并有一个标有 &quot;OK &quot;的按钮，提示用户输入一个整数值。该函数将返回输入的整数，如果没有输入，则返回默认值。</p>
   <p class="note"><b><span class="note">注意</span></b>这个函数<b>只</b>在<span class="notranslate">Windows</span> 目标上用于<b>调试</b>，但在所有其他目标上<b>已被废弃</b>。</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Debugging/get_string.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Debugging/get_string.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">get_string</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">get_string</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>这将创建一个弹出式窗口，显示一条标准信息，有一个标有 &quot;OK &quot;的按钮，提示用户输入一个<span class="notranslate">string</span> 。该函数将返回输入的<span class="notranslate">string</span> ，如果没有输入，<i>则</i>返回默认值。</p>
   <p class="note"><b><span class="note">注意</span></b>这个函数<b>只</b>在<span class="notranslate">Windows</span> 目标上用于<b>调试</b>，但在所有其他目标上<b>已被废弃</b>。</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Particles/effect_create_above.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Particles/effect_create_above.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">effect_create_above</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">effect_create_above</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>通过这个函数，你可以在你的<span class="notranslate">room</span> 的所有实例之上创建一个简单的效果（它实际上是在-100000的深度创建的）。如果效果是其他的 <span class="inline">ef_rain</span> 或 <span class="inline">ef_snow</span> ，那么你可以定义一个x/y位置来创建效果，大小可以是0、1或2的值，其中0是小的，1是中等的，2是大的。</p>
   <p>值得注意的是，这些效果可以通过使用函数来切换它们的绘制，以及暂停它们的绘制。 <a href="Particle_Systems/part_system_automatic_draw.htm"><span class="inline">part_system_automatic_draw()</span></a>和 <a href="Particle_Systems/part_system_automatic_update.htm"><span class="inline">part_system_automatic_update()</span></a>粒子系统索引的适当值（其中0用于下面的效果，1用于上面的效果）。</p>
   <p>不同粒子种类的可用常数是：。</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Particles/effect_create_below.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Drawing/Particles/effect_create_below.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">effect_create_below</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">effect_create_below</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>通过这个函数，你可以在你的<span class="notranslate">room</span> 的所有实例下面创建一个简单的效果（它实际上是在100000的深度创建的）。如果效果是其他的 <span class="inline">ef_rain</span> 或 <span class="inline">ef_snow</span> ，那么你可以定义一个x/y位置来创建效果，大小可以是0、1或2的值，其中0是小，1是中，2是大。</p>
   <p>值得注意的是，这些效果可以通过使用函数来切换它们的绘制，以及暂停它们的绘制。 <a href="Particle_Systems/part_system_automatic_draw.htm"><span class="inline">part_system_automatic_draw()</span></a>和 <a href="Particle_Systems/part_system_automatic_update.htm"><span class="inline">part_system_automatic_update()</span></a>粒子系统索引的适当值（其中0用于下面的效果，1用于上面的效果）。</p>
   <p>不同粒子种类的可用常数是：。</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/General_Game_Control/game_id.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/General_Game_Control/game_id.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">game_id</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">game_id</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>这个<b>只读</b>变量返回你所创建的游戏的唯一标识符。如果你需要一个唯一的文件名，或者其他需要识别你的游戏的东西，你可以使用它。这可以在<a href="../../../Settings/Game_Options.htm">游戏选项</a>中设置。</p>
   <p> </p>
   <h4>语法。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Reference/General_Game_Control/game_load.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/General_Game_Control/game_load.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">game_load</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">game_load</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>有了这个功能，你就可以加载一个以前保存过的游戏，用 <a href="game_save.htm"><span class="inline">game_save()</span></a>.请注意，它将恢复用于创建保存的游戏版本，所以在它之后的任何更新都将不可见。欲了解更多信息，请阅读关于 <a href="game_save.htm"><span class="inline">game_save()</span></a>.</p>
   <p> </p>
   <h4>语法。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Reference/General_Game_Control/game_save.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/General_Game_Control/game_save.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">game_save</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">game_save</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>这是一个传统的函数，可以用来保存游戏的当前状态，不建议再使用。使用 "<a href="../File_Handling/File_Handling.htm">文件 "功能</a>来创建一个自定义的保存系统，只保存和加载特定的游戏数据。</p>
   <p><span class="notranslate">assets</span> 这个函数将保存游戏的状态，但是它不会保存当时正在使用的任何动态资源，比如数据结构、表面、<span class="notranslate">runtime</span> ，等等。如果加载这样的保存文件，任何在保存后进行的游戏更新都将不可见，因为它将恢复创建保存时使用的游戏版本。</p>
   <p>请注意，使用该功能创建的保存文件可能不被更新的<a class="glossterm" data-glossterm="运行时间" href="#">Runtime</a>版本所支持，因此用新的保存系统取代该功能是必不可少的，以确保与未来的<span class="notranslate">GameMaker</span> ，以及由于上述原因，对你自己的游戏所做的更新的兼容性。</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Movement_And_Collisions/Collisions/position_change.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Movement_And_Collisions/Collisions/position_change.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">position_change</span> <span data-conref="..\..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">position_change</span> <span data-conref="../../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>这个函数将检查一个位置是否与给定点的<i>任何实例</i>发生碰撞，如果有的话，它将把<b>所有</b>发生碰撞的实例改为所选择的实例<span class="notranslate">object</span> 。你可以将 &quot;perf &quot;参数设置为 <span class="inline">true</span> ，这将迫使<span data-keyref="GameMaker Name">GameMaker</span>执行找到的实例的<strong>Destroy</strong>和<strong>Clean</strong> <strong>Up</strong>事件，以及新实例的<strong>Create</strong>事件，或者 <span class="inline">false</span> ，不执行任何这些事件。请注意，如果你选择不执行Destroy、Clean Up和Create事件，任何使用通常在create事件中定义的变量而创建的实例将使游戏崩溃，因为该变量将不再存在。</p>
   <p> </p>
   <h4>语法。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Reference/OS_And_Compiler/os_device.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/OS_And_Compiler/os_device.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">os_device</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">os_device</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>这个<strong>只读</strong>变量持有下面列出的各种常量值之一，告诉你当前在哪个设备上运行游戏。请注意，这个变量已被弃用，因为函数 <a href="os_get_info.htm"><span class="inline">os_get_info()</span></a>会返回更准确的关于运行游戏的设备的信息。</p>
   <p> </p>
   <h4>语法。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/array_height_2d.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/array_height_2d.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">array_height_2d</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">array_height_2d</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p class="note"><b>警告!由</b>于数组不再局限于1或2维，该函数已被废弃（并被 <span class="inline"><a href="array_length.htm">array_length()</a></span> ），因此该函数仅用于支持传统项目。所有的新项目应该使用当前的方式来创建和访问多维数组（更多信息请看<a href="../../GML_Overview/Arrays.htm">这里</a>）。</p>
   <p>通过这个函数你可以得到一个二维数组的第一维的高度（条目数）。你提供要检查的数组，该函数的输出告诉你它包含多少个初始条目。你可以用函数获得数组第二维的条目数 <a href="array_length_2d.htm"><span class="inline">array_length_2d</span></a>.</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/array_length_1d.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/array_length_1d.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">array_length_1d</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">array_length_1d</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p class="note"><b>警告!由</b>于数组不再局限于1或2维，该函数已被废弃（并被 <span class="inline"><a href="array_length.htm">array_length()</a></span> ），因此该函数仅用于支持传统项目。所有的新项目应该使用当前的方式来创建和访问多维数组（更多信息请看<a href="../../GML_Overview/Arrays.htm">这里</a>）。</p>
   <p>通过这个函数你可以得到一个一维数组的长度（条目数）。对于二维数组，你应该使用 <a href="array_height_2d.htm"><span class="inline">array_height_2d</span></a>和 <a href="array_length_2d.htm"><span class="inline">array_length_2d</span></a>函数。</p>
   <p class="note"><b>重要的是！。 </b>如果数组有超过32,000个条目，这个函数将返回一个错误的值，不应该被使用。</p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/array_length_2d.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Variable_Functions/array_length_2d.htm
@@ -15,7 +15,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">array_length_2d</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">array_length_2d</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p class="note"><b>警告!由</b>于数组不再局限于1或2维，该函数已被废弃（并被 <span class="inline"><a href="array_length.htm">array_length()</a></span> ），因此该函数仅用于支持传统项目。所有的新项目应该使用当前的方式来创建和访问多维数组（更多信息请看<a href="../../GML_Overview/Arrays.htm">这里</a>）。</p>
   <p>通过这个函数你可以得到一个数组的第二维的长度（条目数）。你提供第一维的条目数，该函数将返回该数组的第二维条目数（要想知道第一维的长度，请使用函数 <a href="array_height_2d.htm"><span class="inline">array_height_2D()</span></a>).如果给定的变量不是一个数组，该函数将返回0；如果变量是一个一维数组（因为还有1行），该函数将返回1。</p>
   <p> </p>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Web_And_HTML5/analytics_event.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Web_And_HTML5/analytics_event.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">analytics_event</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">analytics_event</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>这个函数将发送指定的文本到你通过<a href="../../../Settings/Game_Options/HTML5.htm">HTML5游戏选项</a>设置的分析提供者。这个函数可以用来创建一个自定义分析，以跟踪正在使用的供应商范围之外的东西。</p>
   <p> </p>
   <h4>语法。</h4>

--- a/Manual/contents/GameMaker_Language/GML_Reference/Web_And_HTML5/analytics_event_ext.htm
+++ b/Manual/contents/GameMaker_Language/GML_Reference/Web_And_HTML5/analytics_event_ext.htm
@@ -14,7 +14,7 @@
 </head>
 <body>
   <!--<div class="body-scroll" style="top: 150px;">-->
-  <h1><span data-field="title" data-format="default">analytics_event_ext</span> <span data-conref="..\..\..\assets\snippets\Tag_deprecated.hts"> </span></h1>
+  <h1><span data-field="title" data-format="default">analytics_event_ext</span> <span data-conref="../../../assets/snippets/Tag_deprecated.hts"> </span></h1>
   <p>这个函数将发送指定的文本到你通过<a href="../../../Settings/Game_Options/HTML5.htm">HTML5游戏选项</a>设置的分析提供者那里。这个函数可以用来创建一个自定义的分析，以跟踪正在使用的提供者范围之外的东西。
     这个函数可以用来创建一个自定义的分析，以跟踪正在使用的提供商的范围之外的东西，并且还将接受自定义的参数/值对，其中参数是一个<span class="notranslate">string</span> ，值是一个真实的数字。对于谷歌分析，你只能添加一个额外的对，而Flurry将接受多达
     7.</p>


### PR DESCRIPTION
This PR contains more changes for: 

* https://github.com/YoYoGames/GameMaker-Manual/issues/334

Fixed the slashes leading to the tag not showing properly on pages.